### PR TITLE
Create sub-command: kubectl create limit

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -83,6 +83,7 @@ func NewCmdCreate(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.AddCommand(NewCmdCreateSecret(f, out))
 	cmd.AddCommand(NewCmdCreateConfigMap(f, out))
 	cmd.AddCommand(NewCmdCreateServiceAccount(f, out))
+	cmd.AddCommand(NewCmdCreateLimit(f, out))
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/create_limit.go
+++ b/pkg/kubectl/cmd/create_limit.go
@@ -34,12 +34,12 @@ var (
 	//TODO: add/modify examples/
 	limitExample = dedent.Dedent(`
 		# Create new limit named podmax2cpu for pods to have maximum of 2 CPU’s
-		kubectl create limit podmax2cpu --pod-cpu=max=2`)
+		kubectl create limit new --set=pod.cpu.max=3, pod.cpu.default=2, container.memory.min=200M`)
 )
 
 func NewCmdCreateLimit(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		//TODO: dopln pouzitie
+		//TODO: add
 		Use:     "limit NAME []",
 		Short:   "Create a limit with the specified name and properties",
 		Long:    limitLong,
@@ -53,7 +53,7 @@ func NewCmdCreateLimit(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.LimitV1GeneratorName)
-	//TODO: dopln vlajky
+	cmd.Flags().String("set", "", "A comma-delimited set of type.resource.limit=value pairs that define a limit")
 	return cmd
 }
 
@@ -66,7 +66,10 @@ func CreateLimit(f *cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, args 
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.LimitV1GeneratorName:
 		//TODO: vlastnosti
-		generator = &kubectl.LimitGeneratorV1{}
+		generator = &kubectl.LimitGeneratorV1{
+			Name: name,
+			Set: cmdutil.GetFlagString(cmd, "set"),
+		}
 	default:
 		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator %s not supported.", generatorName))
 	}

--- a/pkg/kubectl/cmd/create_limit.go
+++ b/pkg/kubectl/cmd/create_limit.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/renstrom/dedent"
+	"github.com/spf13/cobra"
+
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+var (
+	limitLong = dedent.Dedent(`
+		Create a limit with the specified name and properties.`)
+
+	//TODO: add/modify examples/
+	limitExample = dedent.Dedent(`
+		# Create new limit named podmax2cpu for pods to have maximum of 2 CPU’s
+		kubectl create limit podmax2cpu --pod-cpu=max=2`)
+)
+
+func NewCmdCreateLimit(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		//TODO: dopln pouzitie
+		Use:     "limit NAME []",
+		Short:   "Create a limit with the specified name and properties",
+		Long:    limitLong,
+		Example: limitExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := CreateLimit(f, cmdOut, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddPrinterFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, cmdutil.LimitV1GeneratorName)
+	//TODO: dopln vlajky
+	return cmd
+}
+
+func CreateLimit(f *cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	var generator kubectl.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case cmdutil.LimitV1GeneratorName:
+		//TODO: vlastnosti
+		generator = &kubectl.LimitGeneratorV1{}
+	default:
+		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator %s not supported.", generatorName))
+	}
+	return RunCreateSubcommand(f, cmd, cmdOut, &CreateSubcommandOptions{
+		Name:                name,
+		StructuredGenerator: generator,
+		DryRun:              cmdutil.GetFlagBool(cmd, "dry-run"),
+		OutputFormat:        cmdutil.GetFlagString(cmd, "output"),
+	})
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -165,6 +165,7 @@ const (
 	DeploymentV1Beta1GeneratorName              = "deployment/v1beta1"
 	JobV1Beta1GeneratorName                     = "job/v1beta1"
 	JobV1GeneratorName                          = "job/v1"
+	LimitV1GeneratorName                        = "limit/v1"
 	NamespaceV1GeneratorName                    = "namespace/v1"
 	SecretV1GeneratorName                       = "secret/v1"
 	SecretForDockerRegistryV1GeneratorName      = "secret-for-docker-registry/v1"
@@ -189,6 +190,9 @@ func DefaultGenerators(cmdName string) map[string]kubectl.Generator {
 	generators["autoscale"] = map[string]kubectl.Generator{
 		HorizontalPodAutoscalerV1Beta1GeneratorName: kubectl.HorizontalPodAutoscalerV1Beta1{},
 		HorizontalPodAutoscalerV1GeneratorName:      kubectl.HorizontalPodAutoscalerV1{},
+	}
+	generators["limit"] = map[string]kubectl.Generator{
+		LimitV1GeneratorName: kubectl.LimitGeneratorV1{},
 	}
 	generators["namespace"] = map[string]kubectl.Generator{
 		NamespaceV1GeneratorName: kubectl.NamespaceGeneratorV1{},

--- a/pkg/kubectl/limit.go
+++ b/pkg/kubectl/limit.go
@@ -24,7 +24,8 @@ import (
 
 type LimitGeneratorV1 struct {
 	Name string
-	//TODO: add flags
+
+	Set string
 }
 
 var _ Generator = &LimitGeneratorV1{}
@@ -46,6 +47,7 @@ func (g LimitGeneratorV1) Generate(genericParams map[string]interface{}) (runtim
 	}
 	delegate := &LimitGeneratorV1{
 		Name: params["name"],
+		Set:  params["set"],
 	}
 	return delegate.StructuredGenerate()
 }
@@ -53,6 +55,7 @@ func (g LimitGeneratorV1) Generate(genericParams map[string]interface{}) (runtim
 func (g LimitGeneratorV1) ParamNames() []GeneratorParam {
 	return GeneratorParam{
 		{"name", true},
+		{"set", true},
 	}
 }
 
@@ -61,9 +64,19 @@ func (g *LimitGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 		return nil, err
 	}
 
+	set, err := parseLimitSet(g.Set)
+	if err != nil {
+		return nil, err
+	}
+
 	limit := &api.LimitRange{}
 	limit.Name = g.Name
+	limit.Spec = set
 	return limit, nil
+}
+
+func parseLimitSet(spec string) ([]api.LimitRangeSpec, error) {
+	return nil, fmt.Errorf("kubectl create limit is not implemented yet")
 }
 
 func (g *LimitGeneratorV1) validate() error {

--- a/pkg/kubectl/limit.go
+++ b/pkg/kubectl/limit.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type LimitGeneratorV1 struct {
+	Name string
+	//TODO: add flags
+}
+
+var _ Generator = &LimitGeneratorV1{}
+
+var _ StructuredGenerator = &LimitGeneratorV1{}
+
+func (g LimitGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := ValidateParams(g.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	delegate := &LimitGeneratorV1{
+		Name: params["name"],
+	}
+	return delegate.StructuredGenerate()
+}
+
+func (g LimitGeneratorV1) ParamNames() []GeneratorParam {
+	return GeneratorParam{
+		{"name", true},
+	}
+}
+
+func (g *LimitGeneratorV1) StructuredGenerate() (runtime.Object, error) {
+	if err := g.validate(); err != nil {
+		return nil, err
+	}
+
+	limit := &api.LimitRange{}
+	limit.Name = g.Name
+	return limit, nil
+}
+
+func (g *LimitGeneratorV1) validate() error {
+	if len(g.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	return nil
+}


### PR DESCRIPTION
kubectl create sub-command provides simpler way of how to create resource limits for pods and containers.
Named limit consists of multiple values which are specified by type (pod or container), resource (memory or cpu) and limit specification (max, min, default, defaultRequest, maxLimitRequestRatio)

Suggestion of how the sub-command could be used:

```
kubectl create limit example --set=pod.cpu.max=3, pod.cpu.default=2, container.memory.min=200M --dry-run
```
